### PR TITLE
add experimental support for CoreRT

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+	<add key="nuget" value="https://api.nuget.org/v3/index.json" />
+ </packageSources>
+</configuration>

--- a/src/SaveManager/SaveManager.csproj
+++ b/src/SaveManager/SaveManager.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Humanizer.Core" Version="2.5.16" />
     <PackageReference Include="LibCK2" Version="1.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
   </ItemGroup>
 
 </Project>

--- a/src/ironmunge/ironmunge.csproj
+++ b/src/ironmunge/ironmunge.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="corgit" Version="0.1.0" />
     <PackageReference Include="LibCK2" Version="1.0.1" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
     <PackageReference Include="NAudio" Version="1.9.0-preview2" />
   </ItemGroup>
 


### PR DESCRIPTION
CoreRT would allow us to AOT compile ironmunge into fat native binaries without needing the folder full of .NET Core runtime dependencies. This would make it a bit more user-friendly (no digging through a huge folder) and moderately improve performance.