### PR TITLE
Notification update

### DIFF
--- a/src/ironmunge/ChangeMonitoring.cs
+++ b/src/ironmunge/ChangeMonitoring.cs
@@ -13,6 +13,9 @@ namespace ironmunge
         private const string PendingSound = "Resources/pending.wav";
         private const string SuccessSound = "Resources/success.wav";
 
+        private static bool NotificationSoundsPresent()
+            => File.Exists(FailureSound) && File.Exists(PendingSound) && File.Exists(SuccessSound);
+
         private Task NotificationAsync(string path)
             => PlayNotifications ? SoundUtilities.PlayAsync(path) : Task.CompletedTask;
 
@@ -33,6 +36,8 @@ namespace ironmunge
                 throw new ArgumentNullException(nameof(savePath));
             if (string.IsNullOrEmpty(historyPath))
                 throw new ArgumentNullException(nameof(historyPath));
+            if (PlayNotifications && !NotificationSoundsPresent())
+                throw new InvalidOperationException("Notification sound files are missing and notifications are enabled");
 
             _history = new SaveHistory(historyPath, gitPath);
 

--- a/src/ironmunge/SoundUtilities.cs
+++ b/src/ironmunge/SoundUtilities.cs
@@ -5,7 +5,7 @@ namespace ironmunge
 {
     static class SoundUtilities
     {
-        public static async Task PlayAsync(string path)
+        public static Task PlayAsync(string path)
         {
             var tcs = new TaskCompletionSource<bool>();
             
@@ -25,7 +25,7 @@ namespace ironmunge
                     }
                 };
                 outputDevice.Play();
-                await tcs.Task;
+                return tcs.Task;
             }
         }
     }


### PR DESCRIPTION
Adds a startup check for any missing sounds in `ChangeMonitoring`'s ctor

Change `SoundUtilities.PlayAsync` to return Task instead of awaiting