### PR TITLE
Specify exact version for dotnet-warp

### DIFF
--- a/build/publish-rid.yml
+++ b/build/publish-rid.yml
@@ -4,6 +4,12 @@ parameters:
 
 steps:
 - task: DotNetCoreInstaller@0
+  displayName: 'Install .NET Core SDK 2.2.100'
+  inputs:
+    version: 2.2.100
+- script: dotnet tool update -g dotnet-warp
+  displayName: 'install or update dotnet-warp'
+- task: DotNetCoreInstaller@0
   displayName: 'Install .NET Core SDK 3.0.100-preview-010184'
   inputs:
     version: 3.0.100-preview-010184

--- a/build/publish-rid.yml
+++ b/build/publish-rid.yml
@@ -7,6 +7,10 @@ steps:
   displayName: 'Install .NET Core SDK 2.2.100'
   inputs:
     version: 2.2.100
+- script: dotnet tool install -g dotnet-warp
+  displayName: 'install dotnet-warp'
+  continueOnError: true
+#when we're using sdk >3.0 this will also install
 - script: dotnet tool update -g dotnet-warp
   displayName: 'install or update dotnet-warp'
 - task: DotNetCoreInstaller@0

--- a/build/warp.yml
+++ b/build/warp.yml
@@ -4,15 +4,8 @@ parameters:
   outputPath: ''
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Install .NET Core SDK 2.2.100'
-  inputs:
-    version: 2.2.100
-- script: dotnet tool uninstall -g dotnet-warp
-  displayName: 'uninstall dotnet-warp'
-  continueOnError: true
-- script: dotnet tool install -g dotnet-warp --version 1.0.7
-  displayName: 'install dotnet-warp'
+- script: dotnet tool update -g dotnet-warp
+  displayName: 'install or update dotnet-warp'
 - script: dotnet-warp . -v -r ${{ parameters.runtime }}
   workingDirectory: 'src/${{ parameters.project }}'
   displayName: 'warp project'

--- a/build/warp.yml
+++ b/build/warp.yml
@@ -4,12 +4,15 @@ parameters:
   outputPath: ''
 
 steps:
-- script: dotnet tool update -g dotnet-warp
-  displayName: 'install or update dotnet-warp'
 - task: DotNetCoreInstaller@0
   displayName: 'Install .NET Core SDK 2.2.100'
   inputs:
     version: 2.2.100
+- script: dotnet tool uninstall -g dotnet-warp
+  displayName: 'uninstall dotnet-warp'
+  continueOnError: true
+- script: dotnet tool install -g dotnet-warp --version 1.0.7
+  displayName: 'install dotnet-warp'
 - script: dotnet-warp . -v -r ${{ parameters.runtime }}
   workingDirectory: 'src/${{ parameters.project }}'
   displayName: 'warp project'

--- a/build/warp.yml
+++ b/build/warp.yml
@@ -4,8 +4,6 @@ parameters:
   outputPath: ''
 
 steps:
-- script: dotnet tool update -g dotnet-warp
-  displayName: 'install or update dotnet-warp'
 - script: dotnet-warp . -v -r ${{ parameters.runtime }}
   workingDirectory: 'src/${{ parameters.project }}'
   displayName: 'warp project'


### PR DESCRIPTION
Build failures for non-Windows targets since 2/23 mean a possible regression in dotnet-warp.

We now specify v1.0.7 exactly instead of using `dotnet tool update`