### PR TITLE
Only publish single file during CI build

### DIFF
--- a/build/publish-rid.yml
+++ b/build/publish-rid.yml
@@ -11,10 +11,10 @@ steps:
 # https://github.com/microsoft/azure-pipelines-tasks/issues/11569
     version: 3.0.x
 #   version: 3.x
-- script: dotnet publish -c Release -r ${{ parameters.runtime }} -o ${{ parameters.outputPath }}
+- script: dotnet publish -c Release -r ${{ parameters.runtime }} -p:PublishSingleFile=true -o ${{ parameters.outputPath }}
   workingDirectory: 'src/ironmunge'
   displayName: 'dotnet publish: ironmunge'
-- script: dotnet publish -c Release -r ${{ parameters.runtime }} -o ${{ parameters.outputPath }}
+- script: dotnet publish -c Release -r ${{ parameters.runtime }} -p:PublishSingleFile=true -o ${{ parameters.outputPath }}
   workingDirectory: 'src/SaveManager'
   displayName: 'dotnet publish: SaveManager'
 - task: PublishBuildArtifacts@1

--- a/ironmunge.sln
+++ b/ironmunge.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{398B1DD8
 		build\azure-pipelines.yml = build\azure-pipelines.yml
 		build\deploy-win.sh = build\deploy-win.sh
 		build\publish-rid.yml = build\publish-rid.yml
-		build\warp.yml = build\warp.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "common", "src\common\common.csproj", "{6830F1FB-7903-4756-9378-3884B928BDA7}"

--- a/src/SaveManager/SaveManager.csproj
+++ b/src/SaveManager/SaveManager.csproj
@@ -5,7 +5,6 @@
     <RuntimeIdentifiers>win-x64;win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ironmunge/ironmunge.csproj
+++ b/src/ironmunge/ironmunge.csproj
@@ -5,7 +5,6 @@
     <RuntimeIdentifiers>win-x64;win-x86;osx-x64;linux-x64</RuntimeIdentifiers>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Avoids breaking local build and debug due to not specifying RID. Error seen:

NETSDK1097 It is not supported to publish an application to a single-file without specifying a RuntimeIdentifier. Please either specify a RuntimeIdentifier or set PublishSingleFile to false.